### PR TITLE
メール通信経路の可視化のために必要なHTML要素の追加およびCSSによるレイアウトの作成

### DIFF
--- a/docs/base.css
+++ b/docs/base.css
@@ -1,0 +1,35 @@
+.result-flex{
+  display: flex;
+}
+.square{
+    margin       : 0px 20px 20px;
+    width        : 150px;
+    height       : 150px;
+    background   : #4472c4;
+}
+.square p{
+  margin         : 0px;
+  font-size      : 25px;
+  color          : #ffffff;
+  line-height    : 150px;
+  text-align     : center;
+}
+
+.header-info,.crypto-protocol{
+  font-size      : 20px;
+}
+.arrow {
+  margin         : 0px 65px;
+}
+.arrow .arrow-square {
+  width          : 20px;
+  height         : 50px;
+  position       : relative;
+  background     : #4472c4;
+  left           : 20px;
+}
+.arrow .arrow-traiangle{
+  border         : 30px solid transparent;
+  border-top     : 30px solid #4472c4;
+  width          : 0;
+}

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,6 +5,7 @@
     <meta charset="UTF-8">
     <title>MAID</title>
     <link rel="stylesheet" href="drag_and_drop.css">
+    <link rel="stylesheet" href="base.css">
 </head>
 
 <body>
@@ -15,7 +16,58 @@
         <input type="file" name="file" id="file-input">
     </div>
     <h2>分析結果</h2>
-    <div id="result"></div>
+    <div id="result">
+        <div class="result-flex">
+            <div class="square">
+                <p>サーバ</p>
+            </div>
+            <div class="header-info">
+                <p>
+                    host：hostname.example.com<br>
+                    IP：0.0.0.0<br>
+                    SPF：Pass, DKIM:Pass, DMARC:Pass
+                </p>
+            </div>
+        </div>
+        <div class="result-flex">
+            <div class="arrow">
+                <div class="arrow-square"></div>
+                <div class="arrow-traiangle"></div>
+            </div>
+            <div class="crypto-protocol">
+                <p>
+                    TLS1.0
+                </p>
+            </div>
+        </div>
+        <div class="result-flex">
+            <div class="square">
+                <p>サーバ</p>
+            </div>
+            <div class="header-info">
+                <p>
+                    host：hostname.example.com<br>
+                    IP：0.0.0.0<br>
+                    SPF：Pass, DKIM:Pass, DMARC:Pass
+                </p>
+            </div>
+        </div>
+        <div class="arrow">
+            <div class="arrow-square"></div>
+            <div class="arrow-traiangle"></div>
+        </div>
+        <div class="crypto-protocol"></div>
+        <div class="result-flex">
+            <div class="square">
+                <p>受信者</p>
+            </div>
+            <div class="header-info">
+                <p>
+                    Deliver to：me@hostname.example.com
+                </p>
+            </div>
+        </div>
+    </div>
     <script type="text/javascript" src="analysis_controller.js"></script>
     <script type="text/javascript" src="read_file.js"></script>
 </body>


### PR DESCRIPTION
## Issue
#3 

## 内容
1. `docs/index.html`の`<div id="result"></div>`タグの中にHTML要素を追加．
　※現在はハリボテ
　- 四角形（想定：サーバ，受信者）
　- テキスト（想定：メールヘッダ情報）
　- 矢印　（想定：メール配送の流れ）
2. 追加したHTML要素のレイアウトを作成->`docs/base.css`．

## 確認手順
追加した要素とそのレイアウトについては，
[https://maplizm.github.io/MAID/](https://maplizm.github.io/MAID/)から確認可能．