### PR TITLE
サーバ側の機能(DBへの格納、データ比較)実装のためのファイル追加

### DIFF
--- a/data_compare.py
+++ b/data_compare.py
@@ -1,0 +1,16 @@
+import psycopg2
+
+def recvDataCompare():
+    #受信データとDBに保存されたデータを比較し、比較結果を返す
+    """
+    connection=psycopg2.connect(host="localhost",dbname="postgres",port="5432",user="postgres",password="postgres")
+    cur = connection.cursor()
+    cur.execute("SELECT COUNT(host='hostname.example.com') AS HOST_MATCH, COUNT(ip='0.0.0.0') AS IP_MATCH FROM MAIL_HEADERS;")
+    results = cur.fetchall()
+    cur.close()
+    connection.close()
+
+    """
+    results="IPアドレスの一致件数：2件,ドメインの一致件数：1件"
+    
+    return results

--- a/data_compare.py
+++ b/data_compare.py
@@ -3,7 +3,7 @@ import psycopg2
 def recvDataCompare():
     #受信データとDBに保存されたデータを比較し、比較結果を返す
     """
-    connection=psycopg2.connect(host="localhost",dbname="postgres",port="5432",user="postgres",password="postgres")
+    connection=psycopg2.connect('DBのURL')
     cur = connection.cursor()
     cur.execute("SELECT COUNT(host='hostname.example.com') AS HOST_MATCH, COUNT(ip='0.0.0.0') AS IP_MATCH FROM MAIL_HEADERS;")
     results = cur.fetchall()

--- a/data_register.py
+++ b/data_register.py
@@ -1,0 +1,13 @@
+import psycopg2
+
+def recvDataRegister():
+    #クライアントから受信したデータをDBに格納
+    """
+    connection=psycopg2.connect('DBのURL')
+    cur = connection.cursor()
+    cur.execute("INSERT INTO MAIL_HEADERS (host,ip,spf,dkim,dmarc,crypto_protocol) VALUES ('hostname.example.com','0.0.0.0','Pass','Pass','Pass','TLS');")
+    cur.execute('COMMIT')
+    cur.close()
+    connection.close()
+    
+    """

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 bottle
 gunicorn
+psycopg2

--- a/routing.py
+++ b/routing.py
@@ -1,6 +1,8 @@
 import os
 import bottle
 from bottle import run, get, post, static_file, template, request
+import data_register
+import data_compare
 
 @get("/")
 def index():
@@ -8,7 +10,11 @@ def index():
 
 @post("/")
 def api_call():
-        return str(request.forms.send_data)
+        # 受信データとDBに保存されたデータを比較する関数
+        compareResults=data_compare.recvDataCompare()
+        # DBに受信データを格納する関数
+        data_register.recvDataRegister()
+        return str(compareResult + request.forms.send_data)
 
 @get("/static/<static:path>")
 def get_static(static):


### PR DESCRIPTION
## Issue
#1 

## 内容
1. ファイル追加
　- `data_register.py`（クライアントからの送信データをDBに格納する関数を記述）
　- `data_compare.py`（クライアントからの送信データとDBのデータを比較し、その結果を返す関数を記述）
　※現在はDBに関わる記述はコメントアウト済　
2. ファイル追加に伴い、`routing.py`の記述内容の一部を変更

3. `requirements.txt`の変更
　- DBへの接続のため、`psycopg2`を追加
　
## 確認方法
```
pip install -r requirements.txt
python3 routing.py
```
[http://localhost:5000](http://localhost:5000/)にアクセスし，ファイルをアップロード

自身の環境にて、`psycopg2`のインストールエラーが発生したため、その際の実行コマンドを以下に記述
```
sudo apt install libpq-dev  
pip install psycopg2
```