### PR TITLE
メール全体からcharset=を読み取り，メールで指定されたエンコーディングでファイルを読み込むように修正

### DIFF
--- a/static/read_file.js
+++ b/static/read_file.js
@@ -13,12 +13,26 @@ function makePostRequest(name, text){
     document.body.appendChild(send_form);
     document.send_form.submit();
 }
-function readFile(file) {
+
+function readFile(file){
     /* FileReaderで読み込み、parseEmailを実行。結果をmakePostRequestでサーバへ送信 */
     let fr = new FileReader();
-    fr.readAsText(file);
+    let decoder_utf8 = new TextDecoder();
+    let re = /charset[^;\r\n]*[;\r\n]/i
+    var encoding;
+    fr.readAsArrayBuffer(file)
     fr.onload = function () {
-        let analysis_result = parseEmail(fr.result);
+        let buf = fr.result
+        let text = decoder_utf8.decode(buf);
+        let charset_string = text.match(re);
+        if (charset_string===null){
+            encoding = "UTF-8";/*文字コードがない場合はUS-ASCIIであるため、文字コードが何であってもよい */
+        }else{
+            encoding = charset_string[0].split("=",2)[1].split(";")[0].trim();
+        }
+        let decoder=new TextDecoder(encoding);
+        text=decoder.decode(buf)
+        let analysis_result = parseEmail(text);
         makePostRequest("send_data", JSON.stringify(analysis_result));
     };
 }


### PR DESCRIPTION
issue
===========
Resolve #14 

内容
============
`static/read_file.js`でエンコーディングをメールヘッダの指示に合わせて変更してファイルを読み込むようにした．

確認方法
==============
- `views/index.tpl`をこのプロジェクトのトップにコピーし，`index.html`に改名
- `static_read_file.js`で35行目に`console.log(text)`を記述し，36行目の`makePostReqeust`の行をコメントアウト
- `index.html`をブラウザで開き，日本語で書かれたメールを読み込ませる
- ブラウザの開発者画面のconsoleを見ると，メールが正しい文字コードでデコードされて表示される